### PR TITLE
지도를 예쁘게 그려보아요 🌈

### DIFF
--- a/src/components/molecules/LocalSelector.tsx
+++ b/src/components/molecules/LocalSelector.tsx
@@ -14,7 +14,7 @@ type Color = { r: number; g: number; b: number };
 
 const LocalSelector = ({ selected, idMap, onClick = () => {} }: Props) => {
   const partyColorMap = new Map<string, Color>();
-  const [coloring, setColoring] = useState<"none" | "party">("none");
+  const [coloring, setColoring] = useState<"none" | "party">("party");
   const [localPartyColor, setLocalPartyColor] = useState<Map<string, string>>();
 
   const fetchPartyColor = async () => {
@@ -158,8 +158,9 @@ const LocalSelector = ({ selected, idMap, onClick = () => {} }: Props) => {
       >
         <Switch
           size="default"
+          defaultChecked
           checkedChildren="정당 보기"
-          unCheckedChildren="기본"
+          unCheckedChildren="단색 보기"
           onClick={checked => {
             setColoring(checked ? "party" : "none");
           }}

--- a/src/components/molecules/MetroSelector.tsx
+++ b/src/components/molecules/MetroSelector.tsx
@@ -39,10 +39,10 @@ const MetroSelector = ({ onClick = () => {} }: Props) => {
           css={css`
             fill: ${hover !== group.groupId
               ? MetroInfo[group.groupId].color
-              : "#060606"};
+              : "#E466F5"};
             stroke: ${hover !== group.groupId
               ? MetroInfo[group.groupId].color
-              : "#060606"};
+              : "#E977F4"};
           `}
           onMouseEnter={() => {
             setHover(group.groupId);

--- a/static/MapSVGData.ts
+++ b/static/MapSVGData.ts
@@ -26,13 +26,13 @@ export type MetroID =
 //   "#4CC9F0",
 // ];
 
-// temporary color (green-ish)
+// new colors (pink-ish)
 export const themeColors = [
-  "#00CB83",
-  "#00DA92",
-  "#00E9A1",
-  "#0FF8B0",
-  "#1EFFBF",
+  "#EE87F3",
+  "#F395F3",
+  "#F7A3F2",
+  "#FBB0F2",
+  "#FFBDF1",
 ];
 
 export const MetroInfo: {


### PR DESCRIPTION
## Summary

- 지도 색상을 주요 정당 색과 겹치지 않으면서 흑백 배경의 웹사이트에서 너무 띄지 않는 색으로 변경합니다.
- 지역의회 선택 시 기본적으로 정당 색 기준으로 지도를 보여주도록 설정합니다.

## Screenshots

### 기존
<img width="200" alt="image" src="https://github.com/NewWays-TechForImpactKAIST/frontend/assets/46402016/0c527c35-5088-4daf-af7f-21a513630a2f">

### 변경안
<img width="200" alt="image" src="https://github.com/NewWays-TechForImpactKAIST/frontend/assets/46402016/17168a0b-e233-433e-b060-1cc9b09f3e27">
